### PR TITLE
[libaccounts-glib] Retarget upstream repo url. Contributes to MER#908

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libaccounts-glib"]
 	path = libaccounts-glib
-	url = https://code.google.com/p/accounts-sso.libaccounts-glib/
+	url = https://gitlab.com/accounts-sso/libaccounts-glib.git

--- a/rpm/libaccounts-glib.spec
+++ b/rpm/libaccounts-glib.spec
@@ -3,7 +3,7 @@ Version:        1.18
 Release:        1
 License:        LGPLv2.1
 Summary:        Accounts base library
-URL:            https://code.google.com/p/accounts-sso.libaccounts-glib/
+URL:            https://gitlab.com/accounts-sso/libaccounts-glib
 Group:          System/Libraries
 Source:         %{name}-%{version}.tar.gz
 Patch0:         0001-Remove-gtk-doc-dependency-for-disable-gtk-doc.patch


### PR DESCRIPTION
The upstream repository url has changed from code.google.com to gitlab
due to the imminent closure of code.google.com.

Contributes to MER#908